### PR TITLE
feat: starter workflows for the org Actions baseline

### DIFF
--- a/workflow-templates/coalfire-org-dependabot-auto-merge.properties.json
+++ b/workflow-templates/coalfire-org-dependabot-auto-merge.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Coalfire: Dependabot Auto-Merge",
+  "description": "Gated auto-merge for Dependabot PRs via the org reusable workflow",
+  "iconName": "octicon check-circle",
+  "categories": ["Automation"]
+}

--- a/workflow-templates/coalfire-org-dependabot-auto-merge.yml
+++ b/workflow-templates/coalfire-org-dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Auto-Merge
+
+# Evaluates Dependabot PRs for auto-merge via the org reusable workflow
+# (supply-chain + breaking-change checks, then approve + bypass-merge on green).
+# pull_request_target gives write access on Dependabot PRs (metadata only; never
+# executes PR-branch code). check_suite drives event-driven re-merge: when a
+# PR's checks finish, an already-approved PR that was still building is merged.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  auto-merge:
+    # pull_request_target: only Dependabot PRs. check_suite: pass through — the
+    # reusable workflow's remerge job resolves + filters the associated PR.
+    if: >-
+      github.event_name == 'check_suite' ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot-auto-merge.yml@f68c1a32bfe64aefd9cbcb1db1f0f40339340eda # v0.12.1
+    secrets: inherit

--- a/workflow-templates/coalfire-org-dependabot.properties.json
+++ b/workflow-templates/coalfire-org-dependabot.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Coalfire: Dependabot Refresh",
+  "description": "Auto-detect ecosystems and regenerate dependabot.yml on PRs",
+  "iconName": "octicon check-circle",
+  "categories": ["Automation"]
+}

--- a/workflow-templates/coalfire-org-dependabot.yml
+++ b/workflow-templates/coalfire-org-dependabot.yml
@@ -1,0 +1,18 @@
+name: Refresh dependabot on PR
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    uses: Coalfire-CF/Actions/.github/workflows/org-dependabot.yml@f68c1a32bfe64aefd9cbcb1db1f0f40339340eda # v0.12.1
+    with:
+      head_branch: ${{ github.head_ref || github.ref_name }}  # PR head, or current branch if not a PR
+      include_github_actions: "true"
+      default_interval: "daily"
+      depb_path: ".github/dependabot.yml"
+      commit_message: "chore: refresh dependabot.yml"

--- a/workflow-templates/coalfire-org-gitleaks-pr.properties.json
+++ b/workflow-templates/coalfire-org-gitleaks-pr.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Coalfire: Gitleaks PR Scan",
+  "description": "Secret detection on PR commits via the org reusable workflow",
+  "iconName": "octicon check-circle",
+  "categories": ["Automation"]
+}

--- a/workflow-templates/coalfire-org-gitleaks-pr.yml
+++ b/workflow-templates/coalfire-org-gitleaks-pr.yml
@@ -1,0 +1,9 @@
+name: Gitleaks
+
+on:
+  pull_request:
+    branches: [$default-branch]
+
+jobs:
+  gitleaks:
+    uses: Coalfire-CF/Actions/.github/workflows/org-gitleaks-pr.yml@f68c1a32bfe64aefd9cbcb1db1f0f40339340eda # v0.12.1

--- a/workflow-templates/coalfire-org-md-lint.properties.json
+++ b/workflow-templates/coalfire-org-md-lint.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Coalfire: Markdown Lint",
+  "description": "Lint changed markdown files on PRs via the org reusable workflow",
+  "iconName": "octicon check-circle",
+  "categories": ["Automation"]
+}

--- a/workflow-templates/coalfire-org-md-lint.yml
+++ b/workflow-templates/coalfire-org-md-lint.yml
@@ -1,0 +1,17 @@
+name: Markdown Lint
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - "**.md"
+    branches:
+      - "**"
+  workflow_call:
+
+jobs:
+  check-markdown:
+    uses: Coalfire-CF/Actions/.github/workflows/org-markdown-lint.yml@f68c1a32bfe64aefd9cbcb1db1f0f40339340eda # v0.12.1

--- a/workflow-templates/coalfire-org-release.properties.json
+++ b/workflow-templates/coalfire-org-release.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Coalfire: Org Release",
+  "description": "release-please releases on merge to the default branch via the org reusable workflow",
+  "iconName": "octicon check-circle",
+  "categories": ["Automation"]
+}

--- a/workflow-templates/coalfire-org-release.yml
+++ b/workflow-templates/coalfire-org-release.yml
@@ -1,0 +1,19 @@
+name: Org Release
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - $default-branch
+
+jobs:
+  create-release:
+    uses: Coalfire-CF/Actions/.github/workflows/org-release.yml@f68c1a32bfe64aefd9cbcb1db1f0f40339340eda # v0.12.1
+    secrets: inherit


### PR DESCRIPTION
Adds `workflow-templates/` starter workflows (the five common Actions callers + properties.json each), pinned to Actions v0.12.1 per RFC-0008, with `$default-branch` macros. They appear in every org repo's **Actions → New workflow** tab as suggested Coalfire workflows.

Complementary to the org-repo-bootstrap sweeper (Coalfire-CF/Actions#245): starter workflows cover creation-time discoverability; the sweeper guarantees convergence for repos that skip them, and converges any pin drift these templates accumulate between releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)